### PR TITLE
Parse IP information from tech file (routing and interface)

### DIFF
--- a/dynex.py
+++ b/dynex.py
@@ -11,6 +11,11 @@ Interface.__doc__ = """
 An Interface is a layer 3 construct that is used to identify a device on a network.
 It can correspond to a physical port on a device, or it can be a logical construct.
 """
+Network = namedtuple("Network", ['address', 'mask'])
+Network.__doc__ = """
+A Network is a layer 3 construct denoting a range of consecutive IP addresses that
+are grouped by masks for routing purposes.
+"""
 
 
 class Switch(ABC):

--- a/dynex.py
+++ b/dynex.py
@@ -3,6 +3,14 @@ from collections import namedtuple
 from typing import Any, Callable
 
 Port = namedtuple("Port", ['name'])
+Port.__doc__ = """
+A Port is a layer 2 construct that is used to connect two devices together.
+"""
+Interface = namedtuple("Interface", ['name'])
+Interface.__doc__ = """
+An Interface is a layer 3 construct that is used to identify a device on a network.
+It can correspond to a physical port on a device, or it can be a logical construct.
+"""
 
 
 class Switch(ABC):

--- a/voss/__init__.py
+++ b/voss/__init__.py
@@ -7,3 +7,4 @@ Each included module contains functions for parsing the output of a given comman
 from voss.voss import VOSS
 import voss.state
 import voss.layer2
+import voss.layer3

--- a/voss/layer3.py
+++ b/voss/layer3.py
@@ -1,0 +1,49 @@
+import re
+from typing import Any
+
+from dynex import Interface
+from voss import VOSS
+
+
+@VOSS.parser("show ip interface")
+def get_ip_interfaces(text_lines: list[str]) -> dict[Interface, dict[str, str]]:
+    """
+    parse the output of "show ip interface" and create structured data correlating
+    the local interface name with the ip address and subnet mask
+
+    :param text_lines: the output of "show ip interface" seperated by lines
+    :return: a dictionary holding ip address and subnet mask indexed by interface names
+    """
+    def search_lines() -> tuple[Interface, dict[str, str]]:
+        for line in text_lines:
+            # Check if this line contains IP address information by searching for a valid IP address pattern.
+            matches = re.findall(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', line)
+            if matches:
+                # We have found a line containing IP address information.
+                # The first match is the IP address, the second is the subnet mask.
+                # The interface name is the first word on the line.
+                interface_name = line.split()[0]
+                yield Interface(interface_name), {"IP Address": matches[0], "Subnet Mask": matches[1]}
+    return {iface: data for iface, data in search_lines()}
+
+
+@VOSS.parser("show ip route")
+def get_ip_routes(text_lines: list[str]) -> dict[Interface, dict[str, Any]]:
+    """
+    parse the output of "show ip route" and create structured data correlating
+    an interface with a destination IP address and subnet mask and the next hop IP address
+
+    :param text_lines: the output of "show ip route" seperated by lines
+    :return: a dictionary with destination IP address, mask, next hop indexed by interface names
+    """
+    def search_lines() -> tuple[Interface, dict[str, Any]]:
+        for line in text_lines:
+            # Check if this line contains IP address information by searching for a valid IP address pattern.
+            matches = re.findall(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', line)
+            if matches:
+                # We have found a line containing IP address information.
+                # The first match is the destination IP address, the second is the subnet mask.
+                # There may or may not be a third match, because the next hop may not be an IP address.
+                pass
+
+    pass

--- a/voss/voss.py
+++ b/voss/voss.py
@@ -53,20 +53,23 @@ class VOSS(Switch):
 
     def parse(self) -> dict[NamedTuple, dict[str, Any]]:
         """
-        Return all parsed data from the tech file after joining the results by port name
-        and merging individual port data into a single dictionary.
+        Parse all the data in the tech file for which we have parsing functions.
+        Group the results by the type of the indexing object into a new dictionary.
+        All these new dictionaries are then added to a new dictionary where they're
+        keyed by the name of the type of the indexing object.
 
         :return: combined parsed data
         """
         data = {}
         for cmd, result in self:
-            for port, sub_data in result.items():
-                if port not in data:
-                    data[port] = {}
-                if isinstance(sub_data, dict):
-                    data[port].update(sub_data)
-                else:
-                    data[port][type(sub_data)] = sub_data
+            for indexing_object, sub_data in result.items():
+                t = type(indexing_object)
+                if t not in data:
+                    data[t] = {}
+                if indexing_object not in data[t]:
+                    data[t][indexing_object] = {}
+                d = sub_data if isinstance(sub_data, dict) else {type(sub_data): sub_data}
+                data[t][indexing_object].update(d)
         return data
 
 

--- a/voss/voss.py
+++ b/voss/voss.py
@@ -1,8 +1,8 @@
 import re
 from pathlib import Path
 from collections.abc import Collection
-from typing import Any
-from dynex import Switch, Port
+from typing import Any, NamedTuple
+from dynex import Switch
 
 
 class VOSS(Switch):
@@ -30,7 +30,7 @@ class VOSS(Switch):
         with open(tech_file_path, 'r') as f:
             return cls(f.readlines())
 
-    def __getitem__(self, command: str) -> dict[Port, Any]:
+    def __getitem__(self, command: str) -> dict[NamedTuple, Any]:
         """
         Run the parsing function for a given command and return the result.
         This is less memory efficient than iteration over the VOSS object, but it is more convenient.
@@ -41,7 +41,7 @@ class VOSS(Switch):
         _, lines = _extract_commands(self.tech_file, [command])
         return self._commands[command](lines)
 
-    def __iter__(self) -> tuple[str, dict[Port, Any]]:
+    def __iter__(self) -> tuple[str, dict[NamedTuple, Any]]:
         """
         Iterate over the commands in the tech file and return the command and the parsed results.
         This is more memory efficient than direct call, but it is less convenient.
@@ -51,7 +51,7 @@ class VOSS(Switch):
         for cmd, lines in _extract_commands(self.tech_file, self._commands.keys()):
             yield cmd, self._commands[cmd](lines)
 
-    def parse(self) -> dict[Port, dict[str, Any]]:
+    def parse(self) -> dict[NamedTuple, dict[str, Any]]:
         """
         Return all parsed data from the tech file after joining the results by port name
         and merging individual port data into a single dictionary.


### PR DESCRIPTION
I've introduced two new types for extraction, `Interface` and `Network`. `Interface` represents any of the Layer3 interfaces on the switch. `Network` refers to any "Subnet ID" and "Subnet Mask" pairing. We are using these types to represent the IP interface and routing tables respectively.

Note, the IP interface table does hold a `Network` to describe it's own IP and Mask. Likewise, the routing table holds the outgoing interface as an `Interface` type.